### PR TITLE
Fix and document vocab spreadsheet util

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Example:
 bundle exec ./lookup_uuids.rb http://archive.cnx.org/contents/031da8d3-b525-429c-80cf-6c8ed997733a@9.4 uuids.xlsx
 ```
 
+### vocabulary-sheet.rb
+
+From the cnx folder, run the following command to extract vocabulary terms from glossary sections of a CNX book
+
+```sh
+bundle exec ./vocabulary-sheet.rb --chapters 45,46,47 --cnx-url http://cnx.org/contents/185cbf87-c72e-48f5-b51e-f14f21b5eabd --lo-xlsx ../lo.xlsx --output ../Biology-chapters-45-47.xlsx
+```
+
 ### Tagging
 
 #### lookup_exercises.rb

--- a/cnx/Gemfile
+++ b/cnx/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'axlsx', '~> 2.1.0.pre'
 gem 'oga'
+gem 'roo'
 gem 'hashie'
 gem 'httparty'
 gem 'byebug'

--- a/cnx/Gemfile.lock
+++ b/cnx/Gemfile.lock
@@ -23,6 +23,9 @@ GEM
     oga (2.2)
       ast
       ruby-ll (~> 2.1)
+    roo (2.3.2)
+      nokogiri (~> 1)
+      rubyzip (~> 1.1, < 2.0.0)
     ruby-ll (2.1.2)
       ansi
       ast
@@ -37,6 +40,7 @@ DEPENDENCIES
   hashie
   httparty
   oga
+  roo
 
 BUNDLED WITH
    1.11.2

--- a/cnx/vocabulary-sheet.rb
+++ b/cnx/vocabulary-sheet.rb
@@ -17,8 +17,6 @@ require 'roo'
 
 PROTECTION_PASSWORD = 'openstax'
 
-require 'pry' # REMOVE!
-
 options = {}
 ARGV << '-h' if ARGV.empty?
 OptionParser.new do |opts|


### PR DESCRIPTION
Was failing to run because `roo` was missing from Gemfile and a `require 'pry'` was left in.